### PR TITLE
Sparse xforms

### DIFF
--- a/lib/Alembic/Abc/OSchema.h
+++ b/lib/Alembic/Abc/OSchema.h
@@ -73,22 +73,42 @@ namespace ALEMBIC_VERSION_NS {
 
 
 //-*****************************************************************************
+//! With properties, specific flavors of properties are expressed via the
+//! TypedScalarProperty and the TypedArrayProperty. Compound Properties
+//! are more complex, and the specific flavors require a more complex
+//! treatment - That's what Schemas are. The CompoundProperty equivalent
+//! of a TypedArrayProperty or a TypedScalarProperty.
+//!
+//! A Schema is a collection of grouped properties which implement some
+//! complex object, such as a poly mesh. In the simpelest, standard case,
+//! there will be a compound property at the top with a certain name, and
+//! inside the compound property will be some number of additional properties
+//! that implement the object. In the case of a poly mesh, these properties
+//! would include a list of vertices (a V3fArray), a list of indices
+//! (an Int32Array), and a list of "per-face counts" (also an Int32Array).
+
+
+//-*****************************************************************************
 //! Here is a macro for declaring SCHEMA_INFO
-//! It takes three arguments
+//! It takes these arguments
 //! - the SchemaTitle( a string ),
 //! - the SchemaBaseType( a string ),
-//! - the DefaultSchemaName( a string )
-//! - the name of the SchemaTrait Type to be declared.
+//! - the DefaultSchemaName( a string ),
+//! - whether to set replace when the sparse argument is provided( bool ),
+//! - the name of the SchemaInfo Type to be declared.
 //! - for example:
 //! ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_PolyMesh_v1",
+//!                                  "AbcGeom_GeomBase_v1",
 //!                                  ".geom",
+//!                                  false,
 //!                                  PolyMeshSchemaInfo );
-#define ALEMBIC_ABC_DECLARE_SCHEMA_INFO( STITLE, SBTYP, SDFLT, STDEF )  \
+#define ALEMBIC_ABC_DECLARE_SCHEMA_INFO( STITLE, SBTYP, SDFLT, SPREP, STDEF ) \
 struct STDEF                                                            \
 {                                                                       \
     static const char * title() { return ( STITLE ) ; }                 \
     static const char * defaultName() { return ( SDFLT ); }             \
     static const char * schemaBaseType() { return ( SBTYP ); }          \
+    static bool         replaceOnSparse() { return SPREP; }             \
 }
 
 //-*****************************************************************************
@@ -124,6 +144,16 @@ public:
     static const char * getDefaultSchemaName()
     {
         return INFO::defaultName();
+    }
+
+    //! Returns whether this schema also sets replace in the MetaData if
+    //! kSparse is passed into the args.  For some schemas like xforms it
+    //! doesn't make sense to sparsely override the properties, instead
+    //! you want to replace everything on the schema with a whole set of new
+    //! properties, or even NO properties.
+    static bool replaceOnSparse()
+    {
+        return INFO::replaceOnSparse();
     }
 
     //! This will check whether or not a given entity (as represented by

--- a/lib/Alembic/Abc/OSchemaObject.h
+++ b/lib/Alembic/Abc/OSchemaObject.h
@@ -187,7 +187,7 @@ OSchemaObject<SCHEMA>::OSchemaObject
                  "NULL Parent ObjectWriter in OSchemaObject ctor" );
 
     // The object schema title is derived from the schema's title.
-    // It is never empty.
+    // It is never empty (unless sparse)
     AbcA::MetaData metaData = args.getMetaData();
 
     SparseFlag sparseFlag = kSparse;
@@ -199,11 +199,6 @@ OSchemaObject<SCHEMA>::OSchemaObject
         if ( std::string() != SCHEMA::getSchemaBaseType() )
         {
             metaData.set( "schemaBaseType", SCHEMA::getSchemaBaseType() );
-        }
-
-        if ( SCHEMA::replaceOnSparse() )
-        {
-            metaData.set( "replace", "1" );
         }
     }
 
@@ -221,11 +216,18 @@ OSchemaObject<SCHEMA>::OSchemaObject
         tsIndex = parent->getArchive()->addTimeSampling(*tsPtr);
     }
 
+    AbcA::MetaData schemaMetaData;
+    if ( args.isSparse() && SCHEMA::replaceOnSparse() )
+    {
+        schemaMetaData.set( "replace", "1" );
+    }
+
     // Make the schema.
     m_schema = SCHEMA( m_object->getProperties(),
                        SCHEMA::getDefaultSchemaName(),
                        this->getErrorHandlerPolicy(),
                        tsIndex,
+                       schemaMetaData,
                        sparseFlag );
 
     ALEMBIC_ABC_SAFE_CALL_END_RESET();

--- a/lib/Alembic/Abc/OSchemaObject.h
+++ b/lib/Alembic/Abc/OSchemaObject.h
@@ -200,6 +200,11 @@ OSchemaObject<SCHEMA>::OSchemaObject
         {
             metaData.set( "schemaBaseType", SCHEMA::getSchemaBaseType() );
         }
+
+        if ( SCHEMA::replaceOnSparse() )
+        {
+            metaData.set( "replace", "1" );
+        }
     }
 
     // Make the object.

--- a/lib/Alembic/Abc/Tests/CompileTest.cpp
+++ b/lib/Alembic/Abc/Tests/CompileTest.cpp
@@ -46,7 +46,7 @@ using namespace Alembic::Abc;
 // A bunch of minimal compile tests to make sure the templates compile
 
 // Declare a test schema.
-ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "TestSchema_v1", "", ".test",
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "TestSchema_v1", "", ".test", false,
                                    TestSchemaInfo );
 
 typedef OSchema<TestSchemaInfo> OTestSchema;

--- a/lib/Alembic/AbcCollection/OCollections.cpp
+++ b/lib/Alembic/AbcCollection/OCollections.cpp
@@ -40,6 +40,32 @@ namespace Alembic {
 namespace AbcCollection {
 namespace ALEMBIC_VERSION_NS {
 
+//-*****************************************************************************
+OCollectionsSchema::OCollectionsSchema(
+    Alembic::AbcCoreAbstract::CompoundPropertyWriterPtr iParent,
+    const std::string &iName,
+    const Abc::Argument &iArg0,
+    const Abc::Argument &iArg1,
+    const Abc::Argument &iArg2,
+    const Abc::Argument &iArg3 )
+: Abc::OSchema<CollectionsSchemaInfo>( iParent, iName, iArg0, iArg1,
+                                       iArg2, iArg3 )
+{
+}
+
+//-*****************************************************************************
+OCollectionsSchema::OCollectionsSchema( Abc::OCompoundProperty iParent,
+                                        const std::string &iName,
+                                        const Abc::Argument &iArg0,
+                                        const Abc::Argument &iArg1,
+                                        const Abc::Argument &iArg2)
+: Abc::OSchema<CollectionsSchemaInfo>( iParent.getPtr(), iName,
+                                       GetErrorHandlerPolicy( iParent ),
+                                       iArg0, iArg1, iArg2 )
+{
+}
+
+//-*****************************************************************************
 Abc::OStringArrayProperty
 OCollectionsSchema::createCollection( const std::string &iName,
     const Abc::Argument &iArg0,
@@ -68,6 +94,7 @@ OCollectionsSchema::createCollection( const std::string &iName,
     return Abc::OStringArrayProperty();
 }
 
+//-*****************************************************************************
 Abc::OStringArrayProperty
 OCollectionsSchema::getCollection( size_t i )
 {
@@ -83,7 +110,7 @@ OCollectionsSchema::getCollection( size_t i )
     return Abc::OStringArrayProperty();
 }
 
-
+//-*****************************************************************************
 Abc::OStringArrayProperty
 OCollectionsSchema::getCollection( const std::string & iName )
 {

--- a/lib/Alembic/AbcCollection/OCollections.h
+++ b/lib/Alembic/AbcCollection/OCollections.h
@@ -45,7 +45,7 @@ namespace Alembic {
 namespace AbcCollection {
 namespace ALEMBIC_VERSION_NS {
 
-class ALEMBIC_EXPORT OCollectionsSchema 
+class ALEMBIC_EXPORT OCollectionsSchema
     : public Abc::OSchema<CollectionsSchemaInfo>
 {
 public:
@@ -54,27 +54,32 @@ public:
 
     OCollectionsSchema() {}
 
-    template <class CPROP_PTR>
-    OCollectionsSchema( CPROP_PTR iParent,
+    //! This constructor creates a new collections writer.
+    //! The first argument is an CompoundPropertyWriterPtr to use as a parent.
+    //! The next is the name to give the schema which is usually the default
+    //! name given by OCollections (.collection)   The remaining optional
+    //! arguments can be used to override the ErrorHandlerPolicy, to specify
+    //! MetaData, specify sparse sampling and to set TimeSampling.
+    OCollectionsSchema(
+        Alembic::AbcCoreAbstract::CompoundPropertyWriterPtr iParent,
+        const std::string &iName,
+        const Abc::Argument &iArg0 = Abc::Argument(),
+        const Abc::Argument &iArg1 = Abc::Argument(),
+        const Abc::Argument &iArg2 = Abc::Argument(),
+        const Abc::Argument &iArg3 = Abc::Argument() );
+
+    //! This constructor creates a new collections writer.
+    //! The first argument is an OCompundProperty to use as a parent, and from
+    //! which the ErrorHandlerPolicy is derived.  The next is the name to give
+    //! the schema which is usually the default name given by OCollections
+    //! (.collection) The remaining optional arguments can be used to specify
+    //! MetaData, specify sparse sampling and to set TimeSampling.
+    OCollectionsSchema( Abc::OCompoundProperty iParent,
                         const std::string &iName,
                         const Abc::Argument &iArg0 = Abc::Argument(),
                         const Abc::Argument &iArg1 = Abc::Argument(),
-                        const Abc::Argument &iArg2 = Abc::Argument() )
-    : Abc::OSchema<CollectionsSchemaInfo>( iParent, iName,
-                                           iArg0, iArg1, iArg2 )
-    {
-    }
-    
-    template <class CPROP_PTR>
-    explicit OCollectionsSchema( CPROP_PTR iParent,
-                                 const Abc::Argument &iArg0 = Abc::Argument(),
-                                 const Abc::Argument &iArg1 = Abc::Argument(),
-                                 const Abc::Argument &iArg2 = Abc::Argument() )
-      : Abc::OSchema<CollectionsSchemaInfo>( iParent,
-                                             iArg0, iArg1, iArg2 )
-    {
-    }
-    
+                        const Abc::Argument &iArg2 = Abc::Argument() );
+
     //! Copy constructor.
     OCollectionsSchema( const OCollectionsSchema& iCopy )
         : Abc::OSchema<CollectionsSchemaInfo>()

--- a/lib/Alembic/AbcCollection/SchemaInfoDeclarations.h
+++ b/lib/Alembic/AbcCollection/SchemaInfoDeclarations.h
@@ -46,6 +46,7 @@ namespace ALEMBIC_VERSION_NS {
 ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcCollection_Collections_v1",
                                  "",
                                  ".collection",
+                                 false,
                                  CollectionsSchemaInfo );
 
 }

--- a/lib/Alembic/AbcGeom/IXform.cpp
+++ b/lib/Alembic/AbcGeom/IXform.cpp
@@ -65,8 +65,6 @@ void IXformSchema::init( const Abc::Argument &iArg0,
                                                  iArg0, iArg1 );
     }
 
-    AbcA::ScalarPropertyReaderPtr ops = ptr->getScalarProperty( ".ops" );
-
     m_useArrayProp = false;
 
     const AbcA::PropertyHeader *valsPH = ptr->getPropertyHeader( ".vals" );
@@ -119,6 +117,12 @@ void IXformSchema::init( const Abc::Argument &iArg0,
                 animChannels.insert( (*animSamp)[i] );
             }
         }
+    }
+
+    AbcA::ScalarPropertyReaderPtr ops;
+    if ( ptr->getPropertyHeader( ".ops" ) != NULL )
+    {
+        ops = ptr->getScalarProperty( ".ops" );
     }
 
     if ( ops && ops->getNumSamples() > 0 )

--- a/lib/Alembic/AbcGeom/OFaceSet.cpp
+++ b/lib/Alembic/AbcGeom/OFaceSet.cpp
@@ -44,19 +44,57 @@ namespace Alembic {
 namespace AbcGeom {
 namespace ALEMBIC_VERSION_NS {
 
+//-*****************************************************************************
+OFaceSetSchema::OFaceSetSchema( AbcA::CompoundPropertyWriterPtr iParent,
+                                const std::string &iName,
+                                const Abc::Argument &iArg0,
+                                const Abc::Argument &iArg1,
+                                const Abc::Argument &iArg2,
+                                const Abc::Argument &iArg3 )
+      : OGeomBaseSchema<FaceSetSchemaInfo>( iParent, iName,
+                                            iArg0, iArg1, iArg2, iArg3 )
+{
+    init( iParent, iArg0, iArg1, iArg2, iArg3 );
+}
 
 //-*****************************************************************************
-void OFaceSetSchema::init( uint32_t iTimeSamplingID )
+OFaceSetSchema::OFaceSetSchema( Abc::OCompoundProperty iParent,
+                                const std::string &iName,
+                                const Abc::Argument &iArg0,
+                                const Abc::Argument &iArg1,
+                                const Abc::Argument &iArg2 )
+      : OGeomBaseSchema<FaceSetSchemaInfo>( iParent.getPtr(), iName,
+                                            GetErrorHandlerPolicy( iParent ),
+                                            iArg0, iArg1, iArg2 )
+{
+    init( iParent.getPtr(), iArg0, iArg1, iArg2, Abc::Argument() );
+}
+
+//-*****************************************************************************
+void OFaceSetSchema::init( AbcA::CompoundPropertyWriterPtr iParent,
+                           const Abc::Argument &iArg0,
+                           const Abc::Argument &iArg1,
+                           const Abc::Argument &iArg2,
+                           const Abc::Argument &iArg3 )
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN( "OFaceSetSchema::init()" );
 
-    AbcA::MetaData mdata;
-    SetGeometryScope( mdata, kVertexScope );
+    AbcA::TimeSamplingPtr tsPtr =
+        Abc::GetTimeSampling( iArg0, iArg1, iArg2, iArg3 );
+    uint32_t timeSamplingID =
+        Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2, iArg3 );
+
+    // Add or find the timeSamplingID to use for our properties.
+    if (tsPtr)
+    {
+        timeSamplingID = iParent->getObject()->getArchive()->addTimeSampling(
+            *tsPtr);
+    }
 
     AbcA::CompoundPropertyWriterPtr _this = this->getPtr();
 
     m_facesProperty = Abc::OInt32ArrayProperty( _this, ".faces",
-        iTimeSamplingID );
+                                                timeSamplingID );
 
     m_facesExclusive = kFaceSetNonExclusive;
 

--- a/lib/Alembic/AbcGeom/OFaceSet.h
+++ b/lib/Alembic/AbcGeom/OFaceSet.h
@@ -49,12 +49,6 @@ namespace AbcGeom {
 namespace ALEMBIC_VERSION_NS {
 
 //-*****************************************************************************
-
-// Forward declarations of our friend classes
-class OSubDSchema;
-class OPolyMeshSchema;
-
-//-*****************************************************************************
 class ALEMBIC_EXPORT OFaceSetSchema : public OGeomBaseSchema<FaceSetSchemaInfo>
 {
 public:
@@ -124,68 +118,30 @@ public:
     //! OFaceSetSchema instances created this evaluate to a boolean value of false.
     OFaceSetSchema() {}
 
-    //! This templated, primary constructor creates a new faceset writer.
-    //! The first argument is any Abc (or AbcCoreAbstract) object
-    //! which can intrusively be converted to an CompoundPropertyWriterPtr
-    //! to use as a parent, from which the error handler policy for
-    //! inheritance is also derived.  The remaining optional arguments
+    //! This constructor creates a new faceset writer.
+    //! The first argument is an CompoundPropertyWriterPtr to use as a parent.
+    //! The next is the name to give the schema which is usually the default
+    //! name given by OFaceSet (.faceset)   The remaining optional arguments
     //! can be used to override the ErrorHandlerPolicy, to specify
-    //! MetaData, and to set TimeSamplingType.
-    //! Most typically you won't need to use this ctor because the
-    //! name argument here is only needed if you need to specially
-    //! override the name of the compound property used internally
-    //! by Alembic (for example if you needed to created your
-    //! own dervied class from OFaceSet that needed to hold multiple
-    //! faceset schema compound properties)
-    template <class CPROP_PTR>
-    OFaceSetSchema( CPROP_PTR iParentCompound,
-                     const std::string &iName,
-                     const Abc::Argument &iArg0 = Abc::Argument(),
-                     const Abc::Argument &iArg1 = Abc::Argument(),
-                     const Abc::Argument &iArg2 = Abc::Argument() )
-      : OGeomBaseSchema<FaceSetSchemaInfo>(
-                    GetCompoundPropertyWriterPtr( iParentCompound ),
-                    iName, iArg0, iArg1, iArg2 )
-    {
-        _initTimeSampling ( GetCompoundPropertyWriterPtr( iParentCompound ),
-                            iArg0, iArg1, iArg2 );
-    }
+    //! MetaData, specify sparse sampling and to set TimeSampling.
+    OFaceSetSchema( AbcA::CompoundPropertyWriterPtr iParent,
+                    const std::string &iName,
+                    const Abc::Argument &iArg0 = Abc::Argument(),
+                    const Abc::Argument &iArg1 = Abc::Argument(),
+                    const Abc::Argument &iArg2 = Abc::Argument(),
+                    const Abc::Argument &iArg3 = Abc::Argument() );
 
-    template <class CPROP_PTR>
-    void _initTimeSampling ( CPROP_PTR iParentCompound,
-                     const Abc::Argument &iArg0 = Abc::Argument(),
-                     const Abc::Argument &iArg1 = Abc::Argument(),
-                     const Abc::Argument &iArg2 = Abc::Argument() )
-    {
-        AbcA::TimeSamplingPtr tsPtr =
-            Abc::GetTimeSampling( iArg0, iArg1, iArg2 );
-        uint32_t timeSamplingID =
-            Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2 );
-
-        // Add or find the timeSamplingID to use for our properties.
-        if (tsPtr)
-        {
-            timeSamplingID = iParentCompound->getObject()->getArchive(
-                )->addTimeSampling(*tsPtr);
-        }
-
-        // Meta data and error handling are eaten up by
-        // the super type, so all that's left is time sampling.
-        init( timeSamplingID );
-    }
-
-    template <class CPROP_PTR>
-    explicit OFaceSetSchema( CPROP_PTR iParentCompound,
-                              const Abc::Argument &iArg0 = Abc::Argument(),
-                              const Abc::Argument &iArg1 = Abc::Argument(),
-                              const Abc::Argument &iArg2 = Abc::Argument() )
-      : OGeomBaseSchema<FaceSetSchemaInfo>(
-                            GetCompoundPropertyWriterPtr( iParentCompound ),
-                            iArg0, iArg1, iArg2 )
-    {
-        _initTimeSampling ( GetCompoundPropertyWriterPtr( iParentCompound ),
-                            iArg0, iArg1, iArg2 );
-    }
+    //! This constructor creates a new faceset writer.
+    //! The first argument is an OCompundProperty to use as a parent, and from
+    //! which the ErrorHandlerPolicy is derived.  The next is the name to give
+    //! the schema which is usually the default name given by OFaceSet
+    //! (.faceset) The remaining optional arguments can be used to specify
+    //! MetaData, specify sparse sampling and to set TimeSampling.
+    OFaceSetSchema( Abc::OCompoundProperty iParent,
+                    const std::string &iName,
+                    const Abc::Argument &iArg0 = Abc::Argument(),
+                    const Abc::Argument &iArg1 = Abc::Argument(),
+                    const Abc::Argument &iArg2 = Abc::Argument() );
 
     //! Copy constructor.
     OFaceSetSchema(const OFaceSetSchema& iCopy)
@@ -247,15 +203,14 @@ public:
 protected:
     void _recordExclusivityHint();
 
-    void init( uint32_t iTimeSamplingID );
+    void init( AbcA::CompoundPropertyWriterPtr iParent,
+               const Abc::Argument &iArg0, const Abc::Argument &iArg1,
+               const Abc::Argument &iArg2, const Abc::Argument &iArg3 );
 
     Abc::OInt32ArrayProperty    m_facesProperty;
 
     Abc::OUInt32Property        m_facesExclusiveProperty;
     FaceSetExclusivity          m_facesExclusive;
-
-    friend class OSubDSchema;
-    friend class OPolyMeshSchema;
 };
 
 

--- a/lib/Alembic/AbcGeom/OLight.cpp
+++ b/lib/Alembic/AbcGeom/OLight.cpp
@@ -42,6 +42,59 @@ namespace AbcGeom {
 namespace ALEMBIC_VERSION_NS {
 
 //-*****************************************************************************
+OLightSchema::OLightSchema(
+    AbcA::CompoundPropertyWriterPtr iParent,
+    const std::string &iName,
+    const Abc::Argument &iArg0,
+    const Abc::Argument &iArg1,
+    const Abc::Argument &iArg2,
+    const Abc::Argument &iArg3 )
+: Abc::OSchema<LightSchemaInfo>( iParent, iName, iArg0, iArg1, iArg2, iArg3 )
+{
+    init( iParent, iArg0, iArg1, iArg2, iArg3 );
+}
+
+//-*****************************************************************************
+OLightSchema::OLightSchema( Abc::OCompoundProperty iParent,
+                            const std::string &iName,
+                            const Abc::Argument &iArg0,
+                            const Abc::Argument &iArg1,
+                            const Abc::Argument &iArg2 )
+: Abc::OSchema<LightSchemaInfo>( iParent.getPtr(), iName,
+                                    GetErrorHandlerPolicy( iParent ),
+                                    iArg0, iArg1, iArg2 )
+{
+    init( iParent.getPtr(), iArg0, iArg1, iArg2, Abc::Argument() );
+}
+
+//-*****************************************************************************
+void OLightSchema::init( AbcA::CompoundPropertyWriterPtr iParent,
+                         const Abc::Argument &iArg0,
+                         const Abc::Argument &iArg1,
+                         const Abc::Argument &iArg2,
+                         const Abc::Argument &iArg3 )
+{
+
+    AbcA::TimeSamplingPtr tsPtr = Abc::GetTimeSampling( iArg0, iArg1,
+                                                        iArg2, iArg3 );
+
+    uint32_t tsIndex = Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2, iArg3 );
+
+    // if we specified a valid TimeSamplingPtr, use it to determine the index
+    // otherwise we'll use the index, which defaults to the intrinsic 0 index
+    if (tsPtr)
+    {
+        tsIndex = iParent->getObject()->getArchive()->addTimeSampling( *tsPtr );
+        m_tsPtr = tsPtr;
+    }
+    else
+    {
+        m_tsPtr = iParent->getObject()->getArchive()->getTimeSampling(
+            tsIndex );
+    }
+}
+
+//-*****************************************************************************
 void OLightSchema::setCameraSample( const CameraSample &iSamp )
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN( "OLightSchema::setCameraSample" );

--- a/lib/Alembic/AbcGeom/OLight.h
+++ b/lib/Alembic/AbcGeom/OLight.h
@@ -66,73 +66,30 @@ public:
     //! ...
     OLightSchema() {}
 
-    //! This templated, primary constructor creates a new camera writer.
-    //! The first argument is any Abc (or AbcCoreAbstract) object
-    //! which can intrusively be converted to an CompoundPropertyWriterPtr
-    //! to use as a parent, from which the error handler policy for
-    //! inheritance is also derived.  The remaining optional arguments
+    //! This constructor creates a new light writer.
+    //! The first argument is an CompoundPropertyWriterPtr to use as a parent.
+    //! The next is the name to give the schema which is usually the default
+    //! name given by OLight (.geom)   The remaining optional arguments
     //! can be used to override the ErrorHandlerPolicy, to specify
-    //! MetaData, and to set TimeSampling.
-    template <class CPROP_PTR>
-    OLightSchema( CPROP_PTR iParent,
+    //! MetaData, specify sparse sampling and to set TimeSampling.
+    OLightSchema( AbcA::CompoundPropertyWriterPtr iParent,
                   const std::string &iName,
                   const Abc::Argument &iArg0 = Abc::Argument(),
                   const Abc::Argument &iArg1 = Abc::Argument(),
-                  const Abc::Argument &iArg2 = Abc::Argument() )
-        : Abc::OSchema<LightSchemaInfo>( iParent, iName,
-                                         iArg0, iArg1, iArg2 )
-    {
+                  const Abc::Argument &iArg2 = Abc::Argument(),
+                  const Abc::Argument &iArg3 = Abc::Argument() );
 
-        AbcA::TimeSamplingPtr tsPtr =
-            Abc::GetTimeSampling( iArg0, iArg1, iArg2 );
-        uint32_t tsIndex =
-            Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2 );
-
-        // if we specified a valid TimeSamplingPtr, use it to determine the
-        // index otherwise we'll use the index, which defaults to the intrinsic
-        // 0 index
-        if (tsPtr)
-        {
-            tsIndex = GetCompoundPropertyWriterPtr( iParent )->getObject(
-                )->getArchive()->addTimeSampling(*tsPtr);
-            m_tsPtr = tsPtr;
-        }
-        else
-        {
-            m_tsPtr = GetCompoundPropertyWriterPtr( iParent )->getObject(
-                )->getArchive()->getTimeSampling( tsIndex );
-        }
-    }
-
-    template <class CPROP_PTR>
-    explicit OLightSchema( CPROP_PTR iParent,
-                              const Abc::Argument &iArg0 = Abc::Argument(),
-                              const Abc::Argument &iArg1 = Abc::Argument(),
-                              const Abc::Argument &iArg2 = Abc::Argument() )
-      : Abc::OSchema<LightSchemaInfo>( iParent,
-                                            iArg0, iArg1, iArg2 )
-    {
-
-        AbcA::TimeSamplingPtr tsPtr =
-            Abc::GetTimeSampling( iArg0, iArg1, iArg2 );
-        uint32_t tsIndex =
-            Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2 );
-
-        // if we specified a valid TimeSamplingPtr, use it to determine the
-        // index otherwise we'll use the index, which defaults to the intrinsic
-        // 0 index
-        if (tsPtr)
-        {
-            tsIndex = GetCompoundPropertyWriterPtr( iParent )->getObject(
-                )->getArchive()->addTimeSampling(*tsPtr);
-            m_tsPtr = tsPtr;
-        }
-        else
-        {
-            m_tsPtr = GetCompoundPropertyWriterPtr( iParent )->getObject(
-                )->getArchive()->getTimeSampling( tsIndex );
-        }
-    }
+    //! This constructor creates a new light writer.
+    //! The first argument is an OCompundProperty to use as a parent, and from
+    //! which the ErrorHandlerPolicy is derived.  The next is the name to give
+    //! the schema which is usually the default name given by OLight (.geom)
+    //! The remaining optional arguments can be used to specify MetaData,
+    //! specify sparse sampling and to set TimeSampling.
+    OLightSchema( Abc::OCompoundProperty iParent,
+                     const std::string &iName,
+                     const Abc::Argument &iArg0 = Abc::Argument(),
+                     const Abc::Argument &iArg1 = Abc::Argument(),
+                     const Abc::Argument &iArg2 = Abc::Argument() );
 
     //! Copy constructor.
     OLightSchema(const OLightSchema& iCopy)
@@ -198,6 +155,12 @@ public:
     ALEMBIC_OVERRIDE_OPERATOR_BOOL( OLightSchema::valid() );
 
 protected:
+
+    void init( AbcA::CompoundPropertyWriterPtr iParent,
+               const Abc::Argument &iArg0,
+               const Abc::Argument &iArg1,
+               const Abc::Argument &iArg2,
+               const Abc::Argument &iArg3 );
 
     AbcA::TimeSamplingPtr m_tsPtr;
 

--- a/lib/Alembic/AbcGeom/OPolyMesh.h
+++ b/lib/Alembic/AbcGeom/OPolyMesh.h
@@ -172,7 +172,7 @@ public:
     //! This constructor creates a new poly mesh writer.
     //! The first argument is an CompoundPropertyWriterPtr to use as a parent.
     //! The next is the name to give the schema which is usually the default
-    //! name given by OFaceSet (.geom)   The remaining optional arguments
+    //! name given by OPolyMesh (.geom)   The remaining optional arguments
     //! can be used to override the ErrorHandlerPolicy, to specify
     //! MetaData, specify sparse sampling and to set TimeSampling.
     OPolyMeshSchema( AbcA::CompoundPropertyWriterPtr iParent,
@@ -185,7 +185,7 @@ public:
     //! This constructor creates a new poly mesh writer.
     //! The first argument is an OCompundProperty to use as a parent, and from
     //! which the ErrorHandlerPolicy is derived.  The next is the name to give
-    //! the schema which is usually the default name given by OFaceSet (.geom)
+    //! the schema which is usually the default name given by OPolyMesh (.geom)
     //! The remaining optional arguments can be used to specify MetaData,
     //! specify sparse sampling and to set TimeSampling.
     OPolyMeshSchema( Abc::OCompoundProperty iParent,

--- a/lib/Alembic/AbcGeom/OSubD.cpp
+++ b/lib/Alembic/AbcGeom/OSubD.cpp
@@ -966,9 +966,10 @@ void OSubDSchema::selectiveSet( const Sample &iSamp )
         m_subdSchemeProperty.set( iSamp.getSubdivisionScheme() );
     }
 
-    if (( iSamp.getCreaseIndices() || iSamp.getCreaseLengths() ||
-        iSamp.getCreaseSharpnesses() )
-        && (!m_creaseIndicesProperty && !m_creaseLengthsProperty && !m_creaseSharpnessesProperty) )
+    if ( ( iSamp.getCreaseIndices() || iSamp.getCreaseLengths() ||
+           iSamp.getCreaseSharpnesses() ) &&
+        ( !m_creaseIndicesProperty && !m_creaseLengthsProperty &&
+          !m_creaseSharpnessesProperty ) )
     {
         initCreases(0);
     }
@@ -988,8 +989,8 @@ void OSubDSchema::selectiveSet( const Sample &iSamp )
         m_creaseSharpnessesProperty.set( iSamp.getCreaseSharpnesses() );
     }
 
-    if ( iSamp.getCornerIndices() || iSamp.getCornerSharpnesses()
-            && (!m_cornerIndicesProperty && ! m_cornerSharpnessesProperty))
+    if ( ( iSamp.getCornerIndices() || iSamp.getCornerSharpnesses() ) &&
+         ( !m_cornerIndicesProperty && !m_cornerSharpnessesProperty ) )
     {
         initCorners(0);
     }

--- a/lib/Alembic/AbcGeom/OSubD.h
+++ b/lib/Alembic/AbcGeom/OSubD.h
@@ -41,9 +41,9 @@
 #include <Alembic/Util/Export.h>
 #include <Alembic/AbcGeom/Foundation.h>
 #include <Alembic/AbcGeom/SchemaInfoDeclarations.h>
+#include <Alembic/AbcGeom/OGeomBase.h>
 #include <Alembic/AbcGeom/OFaceSet.h>
 #include <Alembic/AbcGeom/OGeomParam.h>
-#include <Alembic/AbcGeom/OGeomBase.h>
 
 namespace Alembic {
 namespace AbcGeom {
@@ -51,7 +51,7 @@ namespace ALEMBIC_VERSION_NS {
 
 //-*****************************************************************************
 // for default values for int scalar properties here
-static ALEMBIC_EXPORT_CONST 
+static ALEMBIC_EXPORT_CONST
 int32_t ABC_GEOM_SUBD_NULL_INT_VALUE( INT_MIN / 2 );
 
 //-*****************************************************************************
@@ -313,10 +313,10 @@ public:
     //! ...
     OSubDSchema() {}
 
-    //! This constructor creates a new poly mesh writer.
+    //! This constructor creates a new subd writer.
     //! The first argument is an CompoundPropertyWriterPtr to use as a parent.
     //! The next is the name to give the schema which is usually the default
-    //! name given by OFaceSet (.geom)   The remaining optional arguments
+    //! name given by OSubD (.geom)   The remaining optional arguments
     //! can be used to override the ErrorHandlerPolicy, to specify
     //! MetaData, specify sparse sampling and to set TimeSampling.
     OSubDSchema( AbcA::CompoundPropertyWriterPtr iParent,
@@ -326,10 +326,10 @@ public:
                      const Abc::Argument &iArg2 = Abc::Argument(),
                      const Abc::Argument &iArg3 = Abc::Argument() );
 
-    //! This constructor creates a new poly mesh writer.
+    //! This constructor creates a new subd writer.
     //! The first argument is an OCompundProperty to use as a parent, and from
     //! which the ErrorHandlerPolicy is derived.  The next is the name to give
-    //! the schema which is usually the default name given by OFaceSet (.geom)
+    //! the schema which is usually the default name given by OSubD (.geom)
     //! The remaining optional arguments can be used to specify MetaData,
     //! specify sparse sampling and to set TimeSampling.
     OSubDSchema( Abc::OCompoundProperty iParent,

--- a/lib/Alembic/AbcGeom/OXform.cpp
+++ b/lib/Alembic/AbcGeom/OXform.cpp
@@ -82,6 +82,62 @@ public:
 };
 
 //-*****************************************************************************
+OXformSchema::OXformSchema( AbcA::CompoundPropertyWriterPtr  iParent,
+                            const std::string &iName,
+                            const Abc::Argument &iArg0,
+                            const Abc::Argument &iArg1,
+                            const Abc::Argument &iArg2,
+                            const Abc::Argument &iArg3 )
+    : Abc::OSchema<XformSchemaInfo>( iParent, iName,
+                                     iArg0, iArg1, iArg2, iArg3 )
+{
+
+    // Meta data and error handling are eaten up by
+    // the super type, so all that's left is time sampling.
+    AbcA::TimeSamplingPtr tsPtr =
+        Abc::GetTimeSampling( iArg0, iArg1, iArg2, iArg3 );
+
+    AbcA::index_t tsIndex =
+        Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2, iArg3 );
+
+    if ( tsPtr )
+    {
+        tsIndex = GetCompoundPropertyWriterPtr( iParent )->getObject(
+                        )->getArchive()->addTimeSampling( *tsPtr );
+    }
+
+    init( tsIndex );
+}
+
+//-*****************************************************************************
+OXformSchema::OXformSchema( Abc::OCompoundProperty iParent,
+                            const std::string &iName,
+                            const Abc::Argument &iArg0,
+                            const Abc::Argument &iArg1,
+                            const Abc::Argument &iArg2 )
+    : Abc::OSchema<XformSchemaInfo>( iParent.getPtr(), iName,
+                                     GetErrorHandlerPolicy( iParent ),
+                                     iArg0, iArg1, iArg2 )
+{
+
+    // Meta data and error handling are eaten up by
+    // the super type, so all that's left is time sampling.
+    AbcA::TimeSamplingPtr tsPtr =
+        Abc::GetTimeSampling( iArg0, iArg1, iArg2 );
+
+    AbcA::index_t tsIndex =
+        Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2 );
+
+    if ( tsPtr )
+    {
+        tsIndex = GetCompoundPropertyWriterPtr( iParent )->getObject(
+                        )->getArchive()->addTimeSampling( *tsPtr );
+    }
+
+    init( tsIndex );
+}
+
+//-*****************************************************************************
 void OXformSchema::setChannelValues( const std::vector<double> &iVals )
 {
     if ( ! m_valsPWPtr ) { return; }

--- a/lib/Alembic/AbcGeom/OXform.h
+++ b/lib/Alembic/AbcGeom/OXform.h
@@ -73,65 +73,30 @@ public:
     //! ...
     OXformSchema() {}
 
-    //! This templated, primary constructor creates a new xform writer.
-    //! The first argument is any Abc (or AbcCoreAbstract) object
-    //! which can intrusively be converted to an CompoundPropertyWriterPtr
-    //! to use as a parent, from which the error handler policy for
-    //! inheritance is also derived.  The remaining optional arguments
+    //! This constructor creates a new xform writer.
+    //! The first argument is an CompoundPropertyWriterPtr to use as a parent.
+    //! The next is the name to give the schema which is usually the default
+    //! name given by OFaceSet (.xform)  The remaining optional arguments
     //! can be used to override the ErrorHandlerPolicy, to specify
-    //! MetaData, and to set TimeSampling.
-    template <class CPROP_PTR>
-    OXformSchema( CPROP_PTR iParent,
+    //! MetaData, specify sparse sampling and to set TimeSampling.
+    OXformSchema( AbcA::CompoundPropertyWriterPtr iParent,
                   const std::string &iName,
                   const Abc::Argument &iArg0 = Abc::Argument(),
                   const Abc::Argument &iArg1 = Abc::Argument(),
-                  const Abc::Argument &iArg2 = Abc::Argument() )
-      : Abc::OSchema<XformSchemaInfo>( iParent, iName,
-                                       iArg0, iArg1, iArg2 )
-    {
-        // Meta data and error handling are eaten up by
-        // the super type, so all that's left is time sampling.
-        AbcA::TimeSamplingPtr tsPtr =
-            Abc::GetTimeSampling( iArg0, iArg1, iArg2 );
+                  const Abc::Argument &iArg2 = Abc::Argument(),
+                  const Abc::Argument &iArg3 = Abc::Argument() );
 
-        AbcA::index_t tsIndex =
-            Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2 );
-
-        if ( tsPtr )
-        {
-            tsIndex = GetCompoundPropertyWriterPtr( iParent )->getObject(
-                        )->getArchive()->addTimeSampling( *tsPtr );
-        }
-
-        init( tsIndex );
-    }
-
-    //! This constructor does the same as the above, but uses the default
-    //! name from the XformSchemaInfo struct.
-    template <class CPROP_PTR>
-    explicit OXformSchema( CPROP_PTR iParent,
-                           const Abc::Argument &iArg0 = Abc::Argument(),
-                           const Abc::Argument &iArg1 = Abc::Argument(),
-                           const Abc::Argument &iArg2 = Abc::Argument() )
-      : Abc::OSchema<XformSchemaInfo>( iParent,
-                                       iArg0, iArg1, iArg2 )
-    {
-        // Meta data and error handling are eaten up by
-        // the super type, so all that's left is time sampling.
-        AbcA::TimeSamplingPtr tsPtr =
-            Abc::GetTimeSampling( iArg0, iArg1, iArg2 );
-
-        AbcA::index_t tsIndex =
-            Abc::GetTimeSamplingIndex( iArg0, iArg1, iArg2 );
-
-        if ( tsPtr )
-        {
-            tsIndex = GetCompoundPropertyWriterPtr( iParent )->getObject(
-                    )->getArchive()->addTimeSampling( *tsPtr );
-        }
-
-        init( tsIndex );
-    }
+    //! This constructor creates a new xform writer.
+    //! The first argument is an OCompundProperty to use as a parent, and from
+    //! which the ErrorHandlerPolicy is derived.  The next is the name to give
+    //! the schema which is usually the default name given by OXform (.xform)
+    //! The remaining optional arguments can be used to specify MetaData,
+    //! specify sparse sampling and to set TimeSampling.
+    OXformSchema( Abc::OCompoundProperty iParent,
+                  const std::string &iName,
+                  const Abc::Argument &iArg0 = Abc::Argument(),
+                  const Abc::Argument &iArg1 = Abc::Argument(),
+                  const Abc::Argument &iArg2 = Abc::Argument() );
 
     //! Explicit copy constructor to work around MSVC bug
     OXformSchema( const OXformSchema &iCopy )

--- a/lib/Alembic/AbcGeom/SchemaInfoDeclarations.h
+++ b/lib/Alembic/AbcGeom/SchemaInfoDeclarations.h
@@ -37,6 +37,7 @@
 #ifndef _Alembic_AbcGeom_SchemaInfoDeclarations_h_
 #define _Alembic_AbcGeom_SchemaInfoDeclarations_h_
 
+#include <Alembic/Abc/OSchema.h>
 #include <Alembic/Util/Foundation.h>
 
 namespace Alembic {
@@ -44,134 +45,106 @@ namespace AbcGeom {
 namespace ALEMBIC_VERSION_NS {
 
 //-*****************************************************************************
-//! With properties, specific flavors of properties are expressed via the
-//! TypedScalarProperty and the TypedArrayProperty. Compound Properties
-//! are more complex, and the specific flavors require a more complex
-//! treatment - That's what Schemas are. The CompoundProperty equivalent
-//! of a TypedArrayProperty or a TypedScalarProperty.
-//!
-//! A Schema is a collection of grouped properties which implement some
-//! complex object, such as a poly mesh. In the simpelest, standard case,
-//! there will be a compound property at the top with a certain name, and
-//! inside the compound property will be some number of additional properties
-//! that implement the object. In the case of a poly mesh, these properties
-//! would include a list of vertices (a V3fArray), a list of indices
-//! (an Int32Array), and a list of "per-face counts" (also an Int32Array).
-
-
-//-*****************************************************************************
-//! Here is a macro for declaring SCHEMA_INFO
-//! It takes three arguments
-//! - the SchemaTitle( a string ),
-//! - the SchemaBaseType( a string ),
-//! - the DefaultSchemaName( a string )
-//! - the name of the SchemaInfo Type to be declared.
-//! - for example:
-//! ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_PolyMesh_v1",
-//!                                      "AbcGeom_GeomBase_v1",
-//!                                      ".geom",
-//!                                      PolyMeshSchemaInfo );
-#define ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( STITLE, SBTYP, SDFLT, STDEF ) \
-struct STDEF                                                            \
-{                                                                       \
-    static const char * title() { return ( STITLE ) ; }                 \
-    static const char * defaultName() { return ( SDFLT ); }             \
-    static const char * schemaBaseType() { return ( SBTYP ); }          \
-}
-
-//-*****************************************************************************
-//! Now to declare schema traits using the above macro.  The SCHEMA_INFO are
-//! basically a collection of information about the scheme, acting as an
-//! elaborate typeid
+//! Declare our schema info for AbcGeom
 
 //-*****************************************************************************
 // PolyMesh
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_PolyMesh_v1",
-                                     "AbcGeom_GeomBase_v1",
-                                     ".geom",
-                                     PolyMeshSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_PolyMesh_v1",
+                                 "AbcGeom_GeomBase_v1",
+                                 ".geom",
+                                 false,
+                                 PolyMeshSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_POLYMESH_SCHEMA (PolyMeshSchemaInfo::title())
 
 //-*****************************************************************************
 // NuPatch
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_NuPatch_v2",
-                                     "AbcGeom_GeomBase_v1",
-                                     ".geom",
-                                     NuPatchSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_NuPatch_v2",
+                                 "AbcGeom_GeomBase_v1",
+                                 ".geom",
+                                 false,
+                                 NuPatchSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_NUPATCH_SCHEMA (NuPatchSchemaInfo::title())
 
 //-*****************************************************************************
 // Subdivision surface
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_SubD_v1",
-                                     "AbcGeom_GeomBase_v1",
-                                     ".geom",
-                                     SubDSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_SubD_v1",
+                                 "AbcGeom_GeomBase_v1",
+                                 ".geom",
+                                 false,
+                                 SubDSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_SUBD_SCHEMA (SubDSchemaInfo::title())
 
 //-*****************************************************************************
 // SubD and PolyMesh FaceSet
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_FaceSet_v1",
-                                     "AbcGeom_GeomBase_v1",
-                                     ".faceset",
-                                     FaceSetSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_FaceSet_v1",
+                                 "AbcGeom_GeomBase_v1",
+                                 ".faceset",
+                                 false,
+                                 FaceSetSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_PARITION_SCHEMA (FaceSetSchemaInfo::title())
 
 
 //-*****************************************************************************
 // Points
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_Points_v1",
-                                     "AbcGeom_GeomBase_v1",
-                                     ".geom",
-                                     PointsSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_Points_v1",
+                                 "AbcGeom_GeomBase_v1",
+                                 ".geom",
+                                 false,
+                                 PointsSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_POINTS_SCHEMA (PointsSchemaInfo::title())
 
 //-*****************************************************************************
 // Xform
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_Xform_v3",
-                                     "",
-                                     ".xform",
-                                     XformSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_Xform_v3",
+                                 "",
+                                 ".xform",
+                                 true,
+                                 XformSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_XFORM_SCHEMA (XformSchemaInfo::title())
 
 //-*****************************************************************************
 // Camera
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_Camera_v1",
-                                     "",
-                                     ".geom",
-                                     CameraSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_Camera_v1",
+                                 "",
+                                 ".geom",
+                                 true,
+                                 CameraSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_CAMERA_SCHEMA (CameraSchemaInfo::title())
 
 //-*****************************************************************************
 // Curves
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_Curve_v2",
-                                     "AbcGeom_GeomBase_v1",
-                                     ".geom",
-                                     CurvesSchemaInfo );
-
-//-*****************************************************************************
-// GeomBase
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_GeomBase_v1",
-                                     "",
-                                     ".geom",
-                                     GeomBaseSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_Curve_v2",
+                                 "AbcGeom_GeomBase_v1",
+                                 ".geom",
+                                 false,
+                                 CurvesSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_CURVE_SCHEMA (CurvesSchemaInfo::title())
 
 //-*****************************************************************************
 // Light
-ALEMBIC_ABCGEOM_DECLARE_SCHEMA_INFO( "AbcGeom_Light_v1",
-                                     "",
-                                     ".geom",
-                                     LightSchemaInfo );
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_Light_v1",
+                                 "",
+                                 ".geom",
+                                 true,
+                                 LightSchemaInfo );
 
 #define ALEMBIC_ABCGEOM_LIGHT_SCHEMA (LightSchemaInfo::title())
+
+//-*****************************************************************************
+// GeomBase, meant for convenience IGeomBase only
+ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcGeom_GeomBase_v1",
+                                 "",
+                                 ".geom",
+                                 false,
+                                 GeomBaseSchemaInfo );
 
 } // End namespace ALEMBIC_VERSION_NS
 

--- a/lib/Alembic/AbcGeom/Tests/CMakeLists.txt
+++ b/lib/Alembic/AbcGeom/Tests/CMakeLists.txt
@@ -119,5 +119,10 @@ ADD_EXECUTABLE(AbcGeom_LightTest
 TARGET_LINK_LIBRARIES(AbcGeom_LightTest ${CORE_LIBS})
 ADD_TEST(AbcGeom_LightTest_TEST AbcGeom_LightTest)
 
+ADD_EXECUTABLE(AbcGeom_CameraTest
+               CameraTest.cpp)
+TARGET_LINK_LIBRARIES(AbcGeom_CameraTest ${CORE_LIBS})
+ADD_TEST(AbcGeom_Points_TEST AbcGeom_CameraTest)
+
 ADD_EXECUTABLE(playground PlayGround.cpp)
 TARGET_LINK_LIBRARIES(playground ${CORE_LIBS})

--- a/lib/Alembic/AbcGeom/Tests/CameraTest.cpp
+++ b/lib/Alembic/AbcGeom/Tests/CameraTest.cpp
@@ -36,7 +36,7 @@
 
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcCoreOgawa/All.h>
-
+#include <Alembic/AbcCoreFactory/IFactory.h>
 #include <Alembic/AbcCoreAbstract/Tests/Assert.h>
 
 using namespace Alembic::AbcGeom; // Contains Abc, AbcCoreAbstract
@@ -92,7 +92,8 @@ void cameraTest()
         TESTING_ASSERT( almostEqual( samp.getFStop(), 5.6 ) );
         TESTING_ASSERT( almostEqual( samp.getFocusDistance(), 5.0 ) );
         TESTING_ASSERT( almostEqual( samp.getShutterOpen(), 0.0 ) );
-        TESTING_ASSERT( almostEqual( samp.getShutterClose(), 1.0 ) );
+        TESTING_ASSERT( almostEqual( samp.getShutterClose(),
+                        0.020833333333333332 ) );
         TESTING_ASSERT( almostEqual( samp.getNearClippingPlane(), 0.1 ) );
         TESTING_ASSERT( almostEqual( samp.getFarClippingPlane(), 100000.0 ) );
         TESTING_ASSERT( samp.getNumOps() == 0 );
@@ -115,7 +116,8 @@ void cameraTest()
         TESTING_ASSERT( almostEqual( samp.getFStop(), 5.6 ) );
         TESTING_ASSERT( almostEqual( samp.getFocusDistance(), 5.0 ) );
         TESTING_ASSERT( almostEqual( samp.getShutterOpen(), 0.0 ) );
-        TESTING_ASSERT( almostEqual( samp.getShutterClose(), 1.0 ) );
+        TESTING_ASSERT( almostEqual( samp.getShutterClose(),
+                        0.020833333333333332 ) );
         TESTING_ASSERT( almostEqual( samp.getNearClippingPlane(), 0.1 ) );
         TESTING_ASSERT( almostEqual( samp.getFarClippingPlane(), 100000.0 ) );
         TESTING_ASSERT( samp.getNumOps() == 2 );
@@ -146,7 +148,8 @@ void cameraTest()
         TESTING_ASSERT( almostEqual( samp.getFStop(), 5.6 ) );
         TESTING_ASSERT( almostEqual( samp.getFocusDistance(), 5.0 ) );
         TESTING_ASSERT( almostEqual( samp.getShutterOpen(), 0.0 ) );
-        TESTING_ASSERT( almostEqual( samp.getShutterClose(), 1.0 ) );
+        TESTING_ASSERT( almostEqual( samp.getShutterClose(),
+                        0.020833333333333332) );
         TESTING_ASSERT( almostEqual( samp.getNearClippingPlane(), 0.1 ) );
         TESTING_ASSERT( almostEqual( samp.getFarClippingPlane(), 100000.0 ) );
         TESTING_ASSERT( samp.getNumOps() == 2 );
@@ -222,7 +225,7 @@ void corePropertiesTest()
 
         for ( std::size_t i; i < 10; ++i )
         {
-            cam.getSchema().get( samp );
+            cam.getSchema().get( samp, i );
             TESTING_ASSERT( almostEqual( samp.getFocalLength(),
                 1000.0 * i + 1.0 ) );
             TESTING_ASSERT( almostEqual( samp.getHorizontalAperture(),
@@ -262,9 +265,109 @@ void corePropertiesTest()
 }
 
 //-*****************************************************************************
+void sparseTest()
+{
+    std::string fileA = "sparseCameraA.abc";
+    {
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), fileA );
+        CameraSample samp;
+        OCamera simpleCamObj( OObject( archive, kTop ), "simpleCam" );
+        simpleCamObj.getSchema().set( samp );
+
+        OCamera camObj( OObject( archive, kTop ), "staticCam" );
+        OCameraSchema camSchema = camObj.getSchema();
+        samp.addOp( FilmBackXformOp( kScaleFilmBackOperation, "scale" ) );
+        samp.addOp( FilmBackXformOp( kTranslateFilmBackOperation, "offset" ) );
+        camSchema.set( samp );
+
+        OCamera animCamObj( OObject( archive, kTop ), "animCam" );
+        OCameraSchema animCamSchema = animCamObj.getSchema();
+        animCamSchema.set( samp );
+
+        samp[0].setScale( V2d( 2.0, 3.0 ) );
+        samp[1].setChannelValue( 0, 4.0 );
+        samp[1].setChannelValue( 1, 5.0 );
+        samp.setLensSqueezeRatio( 2.0 );
+        samp.setHorizontalAperture( 4.8 );
+        samp.setVerticalFilmOffset( 3.0 );
+        animCamSchema.set( samp );
+    }
+
+    std::string fileB = "sparseCameraB.abc";
+    {
+        OArchive archive( Alembic::AbcCoreOgawa::WriteArchive(), fileB );
+
+        CameraSample samp;
+        samp.addOp( FilmBackXformOp( kTranslateFilmBackOperation, "test" ) );
+        samp.setLensSqueezeRatio( 5.0 );
+        samp.setHorizontalAperture( 4.0 );
+        samp.setVerticalFilmOffset( 3.0 );
+        samp[0].setChannelValue( 0, 2.0 );
+        samp[0].setChannelValue( 1, 1.0 );
+
+        OCamera simpleCamObj( OObject( archive ), "simpleCam", kSparse );
+        simpleCamObj.getSchema().set( samp );
+
+        OCamera camObj( OObject( archive  ), "staticCam", kSparse );
+        OCameraSchema camSchema = camObj.getSchema();
+        camSchema.set( samp );
+        samp.setLensSqueezeRatio( 10.0 );
+        samp.setHorizontalAperture( 9.0 );
+        samp.setVerticalFilmOffset( 8.0 );
+        samp[0].setChannelValue( 0, 7.0 );
+        samp[0].setChannelValue( 1, 6.0 );
+        camSchema.set( samp );
+
+        OCamera animCamObj( OObject( archive ), "animCam", kSparse );
+        OCameraSchema animCamSchema = animCamObj.getSchema();
+        CameraSample simpleSamp;
+        animCamSchema.set( simpleSamp );
+    }
+
+    {
+        std::vector< std::string > names;
+        names.push_back( fileA );
+        names.push_back( fileB );
+        Alembic::AbcCoreFactory::IFactory factory;
+        IArchive archive = factory.getArchive( names );
+
+        ICamera simpleCamObj( IObject( archive ), "simpleCam" );
+        CameraSample samp;
+        ICameraSchema schema = simpleCamObj.getSchema();
+        TESTING_ASSERT( schema.getNumSamples() == 1 );
+        schema.get( samp );
+        TESTING_ASSERT( samp.getNumOps() == 1 &&
+                        samp.getOp(0).getHint() == "test" );
+
+        ICamera staticCamObj( IObject( archive ), "staticCam" );
+        schema = staticCamObj.getSchema();
+        TESTING_ASSERT( schema.getNumSamples() == 2 );
+        schema.get( samp );
+        TESTING_ASSERT( samp.getLensSqueezeRatio() == 5.0 &&
+                        samp.getHorizontalAperture() == 4.0 &&
+                        samp.getVerticalFilmOffset() == 3.0 &&
+                        samp[0].getChannelValue( 0 ) == 2.0 &&
+                        samp[0].getChannelValue( 1 ) == 1.0 );
+
+        schema.get( samp, 1 );
+        TESTING_ASSERT( samp.getLensSqueezeRatio() == 10.0 &&
+                        samp.getHorizontalAperture() == 9.0 &&
+                        samp.getVerticalFilmOffset() == 8.0 &&
+                        samp[0].getChannelValue( 0 ) == 7.0 &&
+                        samp[0].getChannelValue( 1 ) == 6.0 );
+
+        ICamera animCamObj( IObject( archive ), "animCam" );
+        schema = animCamObj.getSchema();
+        schema.get( samp );
+        TESTING_ASSERT( schema.getNumSamples() == 1 && samp.getNumOps() == 0 );
+    }
+}
+
+//-*****************************************************************************
 int main( int argc, char *argv[] )
 {
     cameraTest();
     corePropertiesTest();
+    sparseTest();
     return 0;
 }

--- a/lib/Alembic/AbcMaterial/OMaterial.cpp
+++ b/lib/Alembic/AbcMaterial/OMaterial.cpp
@@ -42,6 +42,7 @@ namespace Alembic {
 namespace AbcMaterial {
 namespace ALEMBIC_VERSION_NS {
 
+//-*****************************************************************************
 class OMaterialSchema::Data
 {
 public:
@@ -130,12 +131,40 @@ public:
     std::vector<std::string> interfaceStrVec;
 };
 
+//-*****************************************************************************
+OMaterialSchema::OMaterialSchema(
+    Alembic::AbcCoreAbstract::CompoundPropertyWriterPtr iParent,
+    const std::string &iName,
+    const Abc::Argument &iArg0,
+    const Abc::Argument &iArg1,
+    const Abc::Argument &iArg2,
+    const Abc::Argument &iArg3 )
+: Abc::OSchema<MaterialSchemaInfo>( iParent, iName, iArg0, iArg1, iArg2, iArg3 )
+{
+    init();
+}
+
+//-*****************************************************************************
+OMaterialSchema::OMaterialSchema( Abc::OCompoundProperty iParent,
+                                  const std::string &iName,
+                                  const Abc::Argument &iArg0,
+                                  const Abc::Argument &iArg1,
+                                  const Abc::Argument &iArg2 )
+: Abc::OSchema<MaterialSchemaInfo>( iParent.getPtr(), iName,
+                                    GetErrorHandlerPolicy( iParent ),
+                                    iArg0, iArg1, iArg2 )
+{
+    init();
+}
+
+//-*****************************************************************************
 void OMaterialSchema::init()
 {
     m_data = Alembic::Util::shared_ptr< Data >( new Data() );
     m_data->parent = this->getPtr();
 }
 
+//-*****************************************************************************
 void OMaterialSchema::setShader(
         const std::string & iTarget,
         const std::string & iShaderType,
@@ -153,6 +182,7 @@ void OMaterialSchema::setShader(
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
+//-*****************************************************************************
 Abc::OCompoundProperty OMaterialSchema::getShaderParameters(
         const std::string & iTarget,
         const std::string & iShaderType )
@@ -183,6 +213,7 @@ Abc::OCompoundProperty OMaterialSchema::getShaderParameters(
     return Abc::OCompoundProperty();
 }
 
+//-*****************************************************************************
 void OMaterialSchema::createNodeCompound()
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN( "OMaterialSchema::createNodeCompound" );
@@ -195,7 +226,7 @@ void OMaterialSchema::createNodeCompound()
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
-
+//-*****************************************************************************
 void OMaterialSchema::addNetworkNode(
         const std::string & iNodeName,
         const std::string & iTarget,
@@ -222,8 +253,7 @@ void OMaterialSchema::addNetworkNode(
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
-
-
+//-*****************************************************************************
 void OMaterialSchema::setNetworkNodeConnection(
         const std::string & iNodeName,
         const std::string & iInputName,
@@ -254,8 +284,7 @@ void OMaterialSchema::setNetworkNodeConnection(
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
-
-
+//-*****************************************************************************
 Abc::OCompoundProperty OMaterialSchema::getNetworkNodeParameters(
         const std::string & iNodeName )
 {
@@ -289,7 +318,7 @@ Abc::OCompoundProperty OMaterialSchema::getNetworkNodeParameters(
 }
 
 
-
+//-*****************************************************************************
 void OMaterialSchema::setNetworkTerminal(
         const std::string & iTarget,
         const std::string & iShaderType,
@@ -315,6 +344,7 @@ void OMaterialSchema::setNetworkTerminal(
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
+//-*****************************************************************************
 void OMaterialSchema::setNetworkInterfaceParameterMapping(
         const std::string & iInterfaceParamName,
         const std::string & iMapToNodeName,
@@ -333,6 +363,7 @@ void OMaterialSchema::setNetworkInterfaceParameterMapping(
     ALEMBIC_ABC_SAFE_CALL_END();
 }
 
+//-*****************************************************************************
 Abc::OCompoundProperty OMaterialSchema::getNetworkInterfaceParameters()
 {
     ALEMBIC_ABC_SAFE_CALL_BEGIN(

--- a/lib/Alembic/AbcMaterial/OMaterial.h
+++ b/lib/Alembic/AbcMaterial/OMaterial.h
@@ -62,15 +62,19 @@ public:
 
     OMaterialSchema() {}
 
-    OMaterialSchema( Alembic::AbcCoreAbstract::CompoundPropertyWriterPtr iParent,
+    OMaterialSchema(
+        Alembic::AbcCoreAbstract::CompoundPropertyWriterPtr iParent,
+        const std::string &iName,
+        const Abc::Argument &iArg0 = Abc::Argument(),
+        const Abc::Argument &iArg1 = Abc::Argument(),
+        const Abc::Argument &iArg2 = Abc::Argument(),
+        const Abc::Argument &iArg3 = Abc::Argument() );
+
+    OMaterialSchema( Abc::OCompoundProperty iParent,
                      const std::string &iName,
                      const Abc::Argument &iArg0 = Abc::Argument(),
                      const Abc::Argument &iArg1 = Abc::Argument(),
-                     const Abc::Argument &iArg2 = Abc::Argument() )
-    : Abc::OSchema<MaterialSchemaInfo>( iParent, iName, iArg0, iArg1, iArg2 )
-    {
-        init();
-    }
+                     const Abc::Argument &iArg2 = Abc::Argument() );
 
     //! Copy constructor.
     OMaterialSchema( const OMaterialSchema& iCopy )

--- a/lib/Alembic/AbcMaterial/SchemaInfoDeclarations.h
+++ b/lib/Alembic/AbcMaterial/SchemaInfoDeclarations.h
@@ -46,6 +46,7 @@ namespace ALEMBIC_VERSION_NS {
 ALEMBIC_ABC_DECLARE_SCHEMA_INFO( "AbcMaterial_Material_v1",
                                  "",
                                  ".material",
+                                 false,
                                  MaterialSchemaInfo );
 
 }


### PR DESCRIPTION
Add support for setting up sparse xforms, which really just replaces the data beneath .xform with whatever happened to be written in the current layer.

A new boolean method to the SchemaInfo had to be added so this behavior could be defined as part of the schema when the kSparse argument flag was passed in.

Also needed to do some constructor refactoring to OMaterial, OLight, and OCollections to be like everything else.
